### PR TITLE
feat: add publishing and test run workflows (#5)

### DIFF
--- a/.github/workflows/publish-smart-sync.yml
+++ b/.github/workflows/publish-smart-sync.yml
@@ -1,0 +1,48 @@
+name: publish-smart-sync
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  id-token: write   # Required for PyPI Trusted Publishing (OIDC)
+  contents: read
+
+jobs:
+  publish:
+    if: startsWith(github.event.release.tag_name, 'smart-sync-v')
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/hca-smart-sync/
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Poetry
+        run: pipx install poetry
+
+      - name: Build package
+        working-directory: smart-sync
+        run: |
+          poetry build
+          ls -la dist/
+
+      - name: Check metadata (twine)
+        working-directory: smart-sync
+        run: |
+          python -m pip install --upgrade pip
+          pip install --upgrade twine
+          twine check dist/*
+
+      - name: Publish to PyPI (Trusted Publishing)
+        uses: pypa/gh-action-pypi-publish@v1.10.3
+        with:
+          packages-dir: smart-sync/dist
+          # No username/password/token needed with Trusted Publishing

--- a/.github/workflows/smart-sync-ci.yml
+++ b/.github/workflows/smart-sync-ci.yml
@@ -1,0 +1,44 @@
+name: smart-sync CI
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - "smart-sync/**"
+      - ".github/workflows/**"
+  push:
+    branches: [ main ]
+    paths:
+      - "smart-sync/**"
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Poetry
+        run: pipx install poetry
+
+      - name: Install dependencies (with dev)
+        working-directory: smart-sync
+        run: poetry install --with dev
+
+      - name: Lint (ruff)
+        working-directory: smart-sync
+        run: poetry run ruff check src tests
+
+      - name: Run tests (pytest)
+        working-directory: smart-sync
+        run: poetry run pytest -q

--- a/smart-sync/src/hca_smart_sync/cli.py
+++ b/smart-sync/src/hca_smart_sync/cli.py
@@ -1,7 +1,6 @@
 """Command-line interface for HCA Smart Sync."""
 
 import os
-import sys
 import subprocess
 from enum import Enum
 from pathlib import Path
@@ -109,7 +108,7 @@ def _display_upload_plan(files_to_upload: List[Dict], s3_path: str, dry_run: boo
     """Display the upload plan to the user."""
     action = "Would upload" if dry_run else "Will upload"
     
-    console.print(f"\n[bold green]Upload Plan[/bold green]")
+    console.print("\n[bold green]Upload Plan[/bold green]")
     
     table = Table(border_style="bright_black")
     table.add_column("File", style="bright_black")

--- a/smart-sync/src/hca_smart_sync/config/__init__.py
+++ b/smart-sync/src/hca_smart_sync/config/__init__.py
@@ -2,7 +2,7 @@
 
 import os
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, Optional
 
 from pydantic import BaseModel, Field, ConfigDict
 from pydantic_settings import BaseSettings

--- a/smart-sync/src/hca_smart_sync/sync_engine.py
+++ b/smart-sync/src/hca_smart_sync/sync_engine.py
@@ -455,7 +455,8 @@ class SmartSync:
             upload_timeout = self._calculate_upload_timeout(file_size_bytes)
         
         try:
-            # Run with stderr capture only to preserve AWS CLI progress on stdout
+            # Let stdout (progress) stream to console; capture stderr for diagnostics.
+            # With check=True we rely on exceptions for error handling; no need to capture the result.
             subprocess.run(
                 cmd,
                 capture_output=False,  # Let stdout (progress) show naturally

--- a/smart-sync/src/hca_smart_sync/sync_engine.py
+++ b/smart-sync/src/hca_smart_sync/sync_engine.py
@@ -1,6 +1,5 @@
 """Smart sync engine for HCA data uploads."""
 
-import hashlib
 import os
 import shutil
 import subprocess
@@ -10,8 +9,6 @@ from typing import Dict, List, Optional, Tuple
 
 import boto3
 from rich.console import Console
-from rich.prompt import Confirm
-from rich.progress import Progress, SpinnerColumn, TextColumn
 from natsort import natsorted
 
 from hca_smart_sync.config import Config
@@ -459,7 +456,7 @@ class SmartSync:
         
         try:
             # Run with stderr capture only to preserve AWS CLI progress on stdout
-            result = subprocess.run(
+            subprocess.run(
                 cmd,
                 capture_output=False,  # Let stdout (progress) show naturally
                 stderr=subprocess.PIPE,  # Capture stderr for error handling
@@ -535,5 +532,5 @@ class SmartSync:
                 return False
             else:
                 return False
-        except Exception as e:
+        except Exception:
             return False

--- a/smart-sync/tests/test_cli.py
+++ b/smart-sync/tests/test_cli.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 from typer.testing import CliRunner
 import click
+import re
 
 from hca_smart_sync.cli import (
     app, 
@@ -24,6 +25,13 @@ from hca_smart_sync.cli import (
 )
 
 
+# Helper: strip ANSI escape sequences from CLI output for stable assertions
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+def strip_ansi(s: str) -> str:
+    return ANSI_RE.sub("", s)
+
+
 class TestCLI:
     """Test CLI interface."""
     
@@ -35,16 +43,18 @@ class TestCLI:
         """Test CLI help command."""
         result = self.runner.invoke(app, ["--help"])
         
+        out = strip_ansi(result.stdout or result.output)
         assert result.exit_code == 0
-        assert "hca-smart-sync" in result.stdout or "Usage:" in result.stdout
+        assert "hca-smart-sync" in out or "Usage:" in out
     
     def test_sync_command_help(self):
         """Test sync command help (sync is the default command)."""
         result = self.runner.invoke(app, ["--help"])
         
+        out = strip_ansi(result.stdout or result.output)
         assert result.exit_code == 0
-        assert "--dry-run" in result.stdout
-        assert "--verbose" in result.stdout
+        assert "--dry-run" in out
+        assert "--verbose" in out
     
     def test_sync_command_missing_args(self):
         """Test sync command with missing atlas argument."""

--- a/smart-sync/tests/test_cli.py
+++ b/smart-sync/tests/test_cli.py
@@ -4,10 +4,9 @@ import os
 import pytest
 import subprocess
 from pathlib import Path
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import Mock, patch
 from typer.testing import CliRunner
 import click
-import io
 
 from hca_smart_sync.cli import (
     app, 
@@ -21,10 +20,8 @@ from hca_smart_sync.cli import (
     error_msg,
     success_msg,
     format_file_count,
-    format_status,
-    main
+    format_status
 )
-from hca_smart_sync.config import Config
 
 
 class TestCLI:

--- a/smart-sync/tests/test_config.py
+++ b/smart-sync/tests/test_config.py
@@ -1,9 +1,7 @@
 """Tests for HCA Ingest Tools configuration."""
 
-import os
 from pathlib import Path
 
-import pytest
 
 from hca_smart_sync.config import Config, AWSConfig, S3Config
 

--- a/smart-sync/tests/test_smart_sync.py
+++ b/smart-sync/tests/test_smart_sync.py
@@ -8,7 +8,6 @@ import pytest
 
 from hca_smart_sync.checksum import ChecksumCalculator
 from hca_smart_sync.manifest import ManifestGenerator
-from hca_smart_sync.config import Config
 
 
 class TestChecksumCalculator:

--- a/smart-sync/tests/test_sync_engine.py
+++ b/smart-sync/tests/test_sync_engine.py
@@ -3,7 +3,7 @@
 import tempfile
 import subprocess
 from pathlib import Path
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import Mock, patch
 import pytest
 
 from hca_smart_sync.config import Config, AWSConfig, S3Config, ManifestConfig


### PR DESCRIPTION
This pull request introduces two new GitHub Actions workflows for the `smart-sync` package and makes several minor code cleanups to improve maintainability and clarity. The workflows automate CI (testing and linting) and publishing to PyPI, while the code changes remove unused imports and simplify exception handling.

**CI/CD automation:**
* Added `.github/workflows/smart-sync-ci.yml` to run linting and tests on multiple Python versions for all changes to `smart-sync` and its workflows.
* Added `.github/workflows/publish-smart-sync.yml` to automate publishing of `smart-sync` to PyPI when a release is published, using Trusted Publishing.

**Code cleanup and simplification:**
* Removed unused imports from several files (`cli.py`, `sync_engine.py`, `test_cli.py`, `test_config.py`, `test_sync_engine.py`) to improve code clarity. [[1]](diffhunk://#diff-2c1a00fbcec2abf1ab295029bf68e82d7f3aad62f09369b2bc5c8d7eb7ce16eeL4) [[2]](diffhunk://#diff-2be22e71e87e2097d0d15c5b21d5c0e10ca08174b8f6d691eaa71fddb5ddbdafL3) [[3]](diffhunk://#diff-b809b24e41413be4751370a7ae05f904b2cd5b0e390185b22a85930c2af28c43L7-L10) [[4]](diffhunk://#diff-a55c23df5e1ca0b997eba3bb96a538ba30928f2aab598879589a0d46b5e762c6L3-L6) [[5]](diffhunk://#diff-410e5fadfecd2adacfd6ba5c3bb967b36b3b6992a32f832d04af86e33eacce19L6-R6)
* Simplified exception handling in `_validate_s3_access` by removing the unused exception variable.
* Minor formatting and logic tweaks, such as removing unnecessary parentheses and variables, and updating subprocess usage for better output handling. [[1]](diffhunk://#diff-2c1a00fbcec2abf1ab295029bf68e82d7f3aad62f09369b2bc5c8d7eb7ce16eeL112-R111) [[2]](diffhunk://#diff-2be22e71e87e2097d0d15c5b21d5c0e10ca08174b8f6d691eaa71fddb5ddbdafL462-R459) [[3]](diffhunk://#diff-960b32d02c151b21a3272f97fb18caaa7bbeb901ba475116039d2930764dbb05L5-R5) [[4]](diffhunk://#diff-2be22e71e87e2097d0d15c5b21d5c0e10ca08174b8f6d691eaa71fddb5ddbdafL13-L14) [[5]](diffhunk://#diff-b809b24e41413be4751370a7ae05f904b2cd5b0e390185b22a85930c2af28c43L24-L27) [[6]](diffhunk://#diff-562b24c507af877837ca28546444402d68ef94c8752ec501191420fa65da94beL11)