### PR TITLE
fix: use correct tag prefix on publish workflow (#8)

### DIFF
--- a/.github/workflows/publish-smart-sync.yml
+++ b/.github/workflows/publish-smart-sync.yml
@@ -3,6 +3,7 @@ name: publish-smart-sync
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 permissions:
   id-token: write   # Required for PyPI Trusted Publishing (OIDC)
@@ -10,7 +11,7 @@ permissions:
 
 jobs:
   publish:
-    if: startsWith(github.event.release.tag_name, 'smart-sync-v')
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'hca-smart-sync-v')
     runs-on: ubuntu-latest
     environment:
       name: pypi


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for publishing the Smart Sync package. The main change is adding support for manual triggering and refining the conditions for when the publish job runs.

**Workflow improvements:**

* Added the `workflow_dispatch` event to allow manual triggering of the workflow.
* Updated the condition for the publish job so it runs either on manual dispatch or when a release tag starts with `hca-smart-sync-v` (previously only `smart-sync-v`).