### PR TITLE
 fix: specify recent twine version in publish workflow (#8)

### DIFF
--- a/.github/workflows/publish-smart-sync.yml
+++ b/.github/workflows/publish-smart-sync.yml
@@ -38,8 +38,9 @@ jobs:
         working-directory: smart-sync
         run: |
           python -m pip install --upgrade pip
-          pip install --upgrade twine
-          twine check dist/*
+          python -m pip install --upgrade "twine>=5.1.1" "pkginfo>=1.10.0" "packaging>=24.0"
+          python -m twine --version
+          python -m twine check dist/*
 
       - name: Publish to PyPI (Trusted Publishing)
         uses: pypa/gh-action-pypi-publish@v1.10.3

--- a/smart-sync/README.md
+++ b/smart-sync/README.md
@@ -1,6 +1,6 @@
 # HCA Smart-Sync
 
-Intelligent S3 synchronization for HCA Atlas data.
+Intelligent S3 data synchronization for HCA Atlas data.
 
 ## Installation
 
@@ -53,6 +53,7 @@ make format
 ## Configuration
 
 The tool supports environment-based bucket selection:
+
 - `prod` (default): `hca-atlas-tracker-data`
 - `dev`: `hca-atlas-tracker-data-dev`
 


### PR DESCRIPTION
This pull request makes minor improvements to the Python publishing workflow and documentation for the Smart-Sync project. The most important changes include updating the PyPI publishing workflow to use explicit Python module invocations and improving dependency management, as well as minor enhancements to the project README for clarity.

**Publishing workflow improvements:**

* Updated `.github/workflows/publish-smart-sync.yml` to install specific versions of `twine`, `pkginfo`, and `packaging` using `python -m pip`, and switched to invoking `twine` via `python -m twine` for better compatibility and reliability.

**Documentation updates:**

* Reworded the project description in `smart-sync/README.md` for clarity.
* Added a blank line for improved readability in the configuration section of `smart-sync/README.md`.