### PR TITLE
chore: use latest v1 pypi publishing workflow (#8)

### DIFF
--- a/.github/workflows/publish-smart-sync.yml
+++ b/.github/workflows/publish-smart-sync.yml
@@ -44,7 +44,7 @@ jobs:
           python -m twine check dist/*
 
       - name: Publish to PyPI (Trusted Publishing)
-        uses: pypa/gh-action-pypi-publish@v1.10.3
+        uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
           packages-dir: smart-sync/dist
           # No username/password/token needed with Trusted Publishing

--- a/smart-sync/README.md
+++ b/smart-sync/README.md
@@ -1,6 +1,6 @@
 # HCA Smart-Sync
 
-Intelligent S3 data synchronization for HCA Atlas data.
+Intelligent S3 data synchronization for HCA Atlas source datasets and integrated objects.
 
 ## Installation
 


### PR DESCRIPTION
This pull request updates the PyPI publishing workflow to use a newer version of the GitHub Action for publishing Python packages.

Workflow dependency update:

* [`.github/workflows/publish-smart-sync.yml`](diffhunk://#diff-ec0a3737234cdca9f930fa1c459e775029d713c9c4e80e669a583662d25dc5feL47-R47): Upgraded the `pypa/gh-action-pypi-publish` action from version `v1.10.3` to `v1.12.4` to ensure compatibility and benefit from recent improvements.