### PR TITLE
fix: update release please action version (#13)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,7 +13,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,20 @@
       "release-type": "python",
       "package-name": "hca-smart-sync",
       "changelog-path": "smart-sync/CHANGELOG.md",
-      "include-component-in-tag": true
+      "include-component-in-tag": true,
+      "changelog-sections": [
+        { "type": "feat", "section": "Features" },
+        { "type": "fix", "section": "Bug Fixes" },
+        { "type": "chore", "section": "Chores" },
+        { "type": "content", "section": "Content" },
+        { "type": "docs", "section": "Documentation" },
+        { "type": "style", "section": "Styles" },
+        { "type": "refactor", "section": "Code Refactoring" },
+        { "type": "perf", "section": "Performance Improvements" },
+        { "type": "test", "section": "Tests" },
+        { "type": "build", "section": "Build System" },
+        { "type": "ci", "section": "Continuous Integration" }
+      ]
     }
   }
 }

--- a/smart-sync/pyproject.toml
+++ b/smart-sync/pyproject.toml
@@ -43,7 +43,7 @@ ruff = "^0.1.0"
 hca-smart-sync = "hca_smart_sync.cli:main"
 
 [tool.poetry.urls]
-Homepage = "https://github.com/clevercanary/hca-ingest-tools/tree/main/smart-sync"
+Homepage = "https://github.com/clevercanary/hca-ingest-tools/blob/main/smart-sync/README.md"
 Repository = "https://github.com/clevercanary/hca-ingest-tools"
 Issues = "https://github.com/clevercanary/hca-ingest-tools/issues"
 

--- a/smart-sync/src/hca_smart_sync/manifest.py
+++ b/smart-sync/src/hca_smart_sync/manifest.py
@@ -62,7 +62,7 @@ class ManifestGenerator:
     
     def save_manifest(self, manifest: Dict, output_path: Path) -> None:
         """
-        Save manifest to a JSON file.
+        Save the manifest to a JSON file.
         
         Args:
             manifest: The manifest dictionary


### PR DESCRIPTION
This pull request introduces improvements to the release automation configuration and minor documentation updates. The most significant changes are the enhancement of the changelog generation in the release workflow and a small docstring update for clarity.

Release automation and changelog improvements:

* Added detailed changelog section mapping for different commit types in `release-please-config.json`, improving the readability and organization of release notes.
* Updated the GitHub Actions workflow to use the canonical `googleapis/release-please-action@v4` instead of `google-github-actions/release-please-action@v4` for better compatibility and support. (.github/workflows/release-please.yml)

Documentation update:

* Improved the docstring in the `save_manifest` method to clarify its purpose in `manifest.py`.