### PR TITLE
fix: don't crash on launch with no args and switch to explicit commands

### DIFF
--- a/smart-sync/src/hca_smart_sync/cli.py
+++ b/smart-sync/src/hca_smart_sync/cli.py
@@ -20,9 +20,19 @@ from hca_smart_sync.sync_engine import SmartSync
 app = typer.Typer(
     name="hca-smart-sync",
     help="Intelligent S3 synchronization for HCA Atlas data",
+    epilog="💡 Tip: Run 'hca-smart-sync sync --help' for detailed sync command options",
     add_completion=False,  # Disable shell completion for simplicity
 )
 console = Console()
+
+
+@app.callback(invoke_without_command=True)
+def main_callback(ctx: typer.Context) -> None:
+    """HCA Smart-Sync - Intelligent S3 synchronization for HCA Atlas data."""
+    # If no subcommand was invoked, show help
+    if ctx.invoked_subcommand is None:
+        typer.echo(ctx.get_help())
+        raise typer.Exit(0)
 
 # Message templates for consistent formatting
 class Messages:
@@ -386,9 +396,6 @@ def _display_results(result: dict, dry_run: bool) -> None:
 
 def main() -> None:
     """Main entry point for the CLI."""
-    if not _check_aws_cli():
-        _display_aws_cli_installation_help()
-        raise typer.Exit(1)
     app()
 
 

--- a/smart-sync/tests/test_cli.py
+++ b/smart-sync/tests/test_cli.py
@@ -48,8 +48,8 @@ class TestCLI:
         assert "hca-smart-sync" in out or "Usage:" in out
     
     def test_sync_command_help(self):
-        """Test sync command help (sync is the default command)."""
-        result = self.runner.invoke(app, ["--help"])
+        """Test sync command help."""
+        result = self.runner.invoke(app, ["sync", "--help"])
         
         out = strip_ansi(result.stdout or result.output)
         assert result.exit_code == 0
@@ -57,13 +57,13 @@ class TestCLI:
         assert "--verbose" in out
     
     def test_sync_command_missing_args(self):
-        """Test sync command with missing atlas argument shows help."""
-        result = self.runner.invoke(app, [])
+        """Test sync command with missing atlas argument fails."""
+        result = self.runner.invoke(app, ["sync"])
         
-        # Should show help instead of failing
-        assert result.exit_code == 0
-        out = strip_ansi(result.stdout or result.output)
-        assert "Usage:" in out or "hca-smart-sync" in out
+        # Should fail - atlas is required
+        assert result.exit_code != 0
+        out = strip_ansi(result.stderr if result.stderr else result.stdout)
+        assert "Missing argument" in out or "required" in out.lower()
     
     def test_sync_command_with_invalid_atlas(self):
         """Test sync command with invalid atlas name."""
@@ -74,7 +74,7 @@ class TestCLI:
             mock_init.return_value = mock_sync_engine
             
             # Test with an atlas that would likely fail validation
-            result = self.runner.invoke(app, ["invalid-atlas-name", "--dry-run"])
+            result = self.runner.invoke(app, ["sync", "invalid-atlas-name", "--dry-run"])
             
             # Should either fail or show some error (depending on validation)
             # This test mainly ensures the command structure works
@@ -83,7 +83,7 @@ class TestCLI:
     def test_sync_command_with_invalid_environment(self):
         """Test sync command with invalid environment value."""
         # Test with invalid environment value - should be rejected by Typer enum validation
-        result = self.runner.invoke(app, ["gut-v1", "--environment", "devv", "--dry-run"])
+        result = self.runner.invoke(app, ["sync", "gut-v1", "--environment", "devv", "--dry-run"])
         
         # Should fail due to invalid environment enum value
         assert result.exit_code != 0
@@ -107,7 +107,7 @@ class TestCLI:
             # Note: These may still fail later due to AWS access, but enum validation should pass
             
             # Test prod environment
-            result_prod = self.runner.invoke(app, ["gut-v1", "--environment", "prod", "--dry-run"])
+            result_prod = self.runner.invoke(app, ["sync", "gut-v1", "--environment", "prod", "--dry-run"])
             # Should not fail due to enum validation (may fail later for other reasons)
             # If it fails, it shouldn't be due to invalid enum value
             if result_prod.exit_code != 0:
@@ -116,7 +116,7 @@ class TestCLI:
                 assert "Invalid value for '--environment'" not in error_output
             
             # Test dev environment  
-            result_dev = self.runner.invoke(app, ["gut-v1", "--environment", "dev", "--dry-run"])
+            result_dev = self.runner.invoke(app, ["sync", "gut-v1", "--environment", "dev", "--dry-run"])
             # Should not fail due to enum validation (may fail later for other reasons)
             if result_dev.exit_code != 0:
                 error_output = result_dev.stderr if result_dev.stderr else result_dev.stdout
@@ -410,7 +410,7 @@ class TestSyncScenarios:
             mock_init_sync.return_value = mock_sync_engine
             
             runner = CliRunner()
-            result = runner.invoke(app, ["gut-v1", "--profile", "test"])
+            result = runner.invoke(app, ["sync", "gut-v1", "--profile", "test"])
             
             assert result.exit_code == 0
             assert "No .h5ad files found in directory" in result.output
@@ -454,7 +454,7 @@ class TestSyncScenarios:
             mock_init_sync.return_value = mock_sync_engine
             
             runner = CliRunner()
-            result = runner.invoke(app, ["gut-v1", "--profile", "test"])
+            result = runner.invoke(app, ["sync", "gut-v1", "--profile", "test"])
             
             assert result.exit_code == 0
             assert "Found 3 .h5ad files - all up to date" in result.output
@@ -496,7 +496,7 @@ class TestSyncScenarios:
             mock_init_sync.return_value = mock_sync_engine
             
             runner = CliRunner()
-            result = runner.invoke(app, ["gut-v1", "--profile", "test"])
+            result = runner.invoke(app, ["sync", "gut-v1", "--profile", "test"])
             
             assert result.exit_code == 0
             assert "Found 1 .h5ad file - all up to date" in result.output  # Singular "file"


### PR DESCRIPTION
This pull request improves the CLI user experience and test coverage for the HCA Smart-Sync tool. The main enhancements include making the CLI help more accessible when no arguments are provided, updating tests to explicitly use the `sync` subcommand, and ensuring help is shown even if AWS CLI is not installed.

**CLI usability improvements:**

* Added an `epilog` tip to the Typer app to guide users to run `hca-smart-sync sync --help` for more options.
* Introduced a main callback (`main_callback`) so that running the CLI without any arguments now displays the help message and exits cleanly.
* Removed the AWS CLI dependency check from the main entry point, allowing help and command discovery to work even if AWS CLI is not installed.

**Test suite updates:**

* Updated all CLI test invocations to explicitly use the `sync` subcommand, ensuring argument validation and help output are tested in a consistent manner. [[1]](diffhunk://#diff-b809b24e41413be4751370a7ae05f904b2cd5b0e390185b22a85930c2af28c43L51-R66) [[2]](diffhunk://#diff-b809b24e41413be4751370a7ae05f904b2cd5b0e390185b22a85930c2af28c43L75-R77) [[3]](diffhunk://#diff-b809b24e41413be4751370a7ae05f904b2cd5b0e390185b22a85930c2af28c43L84-R86) [[4]](diffhunk://#diff-b809b24e41413be4751370a7ae05f904b2cd5b0e390185b22a85930c2af28c43L108-R110) [[5]](diffhunk://#diff-b809b24e41413be4751370a7ae05f904b2cd5b0e390185b22a85930c2af28c43L117-R119) [[6]](diffhunk://#diff-b809b24e41413be4751370a7ae05f904b2cd5b0e390185b22a85930c2af28c43L382-R413) [[7]](diffhunk://#diff-b809b24e41413be4751370a7ae05f904b2cd5b0e390185b22a85930c2af28c43L426-R457) [[8]](diffhunk://#diff-b809b24e41413be4751370a7ae05f904b2cd5b0e390185b22a85930c2af28c43L468-R499)
* Added a new `TestNoArgsHelp` class to verify that running the CLI with no arguments displays the help message, and that help is accessible even without AWS CLI installed.

These changes collectively make the CLI more user-friendly and robust, especially for new users and in environments where dependencies may be missing.