### PR TITLE
feat: add --version command (#20)

### DIFF
--- a/smart-sync/src/hca_smart_sync/cli.py
+++ b/smart-sync/src/hca_smart_sync/cli.py
@@ -15,6 +15,7 @@ from rich.prompt import Confirm
 
 from hca_smart_sync.config import Config
 from hca_smart_sync.sync_engine import SmartSync
+from hca_smart_sync import __version__
 
 # Create the Typer app instance with proper configuration
 app = typer.Typer(
@@ -27,8 +28,16 @@ console = Console()
 
 
 @app.callback(invoke_without_command=True)
-def main_callback(ctx: typer.Context) -> None:
+def main_callback(
+    ctx: typer.Context,
+    version: Annotated[bool, typer.Option("--version", help="Show version and exit")] = False,
+) -> None:
     """HCA Smart-Sync - Intelligent S3 synchronization for HCA Atlas data."""
+    # Handle version flag
+    if version:
+        typer.echo(f"hca-smart-sync {__version__}")
+        raise typer.Exit(0)
+    
     # If no subcommand was invoked, show help
     if ctx.invoked_subcommand is None:
         typer.echo(ctx.get_help())

--- a/smart-sync/tests/test_cli.py
+++ b/smart-sync/tests/test_cli.py
@@ -47,6 +47,16 @@ class TestCLI:
         assert result.exit_code == 0
         assert "hca-smart-sync" in out or "Usage:" in out
     
+    def test_cli_version(self):
+        """Test --version flag shows version."""
+        result = self.runner.invoke(app, ["--version"])
+        
+        out = strip_ansi(result.stdout or result.output)
+        assert result.exit_code == 0
+        assert "hca-smart-sync" in out
+        # Version should be in format like "0.2.3"
+        assert any(char.isdigit() for char in out), "Version output should contain version number"
+    
     def test_sync_command_help(self):
         """Test sync command help."""
         result = self.runner.invoke(app, ["sync", "--help"])


### PR DESCRIPTION
This pull request adds a new --version flag to the CLI, allowing users to easily check the current version of the `hca-smart-sync` tool. It also introduces a corresponding test to ensure this functionality works as expected.

New CLI feature:

* Added a `--version` flag to the main CLI using Typer, which prints the current version of `hca-smart-sync` and exits. This uses the `__version__` variable from the package. [[1]](diffhunk://#diff-2c1a00fbcec2abf1ab295029bf68e82d7f3aad62f09369b2bc5c8d7eb7ce16eeR18) [[2]](diffhunk://#diff-2c1a00fbcec2abf1ab295029bf68e82d7f3aad62f09369b2bc5c8d7eb7ce16eeL30-R40)

Testing improvements:

* Added a test case to verify that running the CLI with `--version` outputs the version string and exits successfully.